### PR TITLE
Rename Compact => Values

### DIFF
--- a/Maybe.Test/MaybeEnumerableExtensionsTests.cs
+++ b/Maybe.Test/MaybeEnumerableExtensionsTests.cs
@@ -232,14 +232,14 @@ namespace Maybe.Test
         }
 
         [Theory]
-        [MemberData(nameof(Compact_WithEnumerableOfMaybe_ReturnsValuesTestCases))]
-        public void Compact_WithEnumerableOfMaybe_ReturnsValues(IList<Maybe<string>> subject, IList<string> expected)
+        [MemberData(nameof(Values_WithEnumerableOfMaybe_ReturnsValuesTestCases))]
+        public void Values_WithEnumerableOfMaybe_ReturnsValues(IList<Maybe<string>> subject, IList<string> expected)
         {
-            var result = subject.Compact();
+            var result = subject.Values();
             result.Should().BeEquivalentTo(expected, opt => opt.WithStrictOrdering());
         }
 
-        public static TheoryData<IList<Maybe<string>>, IList<string>> Compact_WithEnumerableOfMaybe_ReturnsValuesTestCases()
+        public static TheoryData<IList<Maybe<string>>, IList<string>> Values_WithEnumerableOfMaybe_ReturnsValuesTestCases()
         {
             return new TheoryData<IList<Maybe<string>>, IList<string>>
             {
@@ -270,37 +270,10 @@ namespace Maybe.Test
             };
         }
 
-        [Theory]
-        [MemberData(nameof(Compact_WithEnumerableOfNullables_ReturnsValuesTestCases))]
-        public void Compact_WithEnumerableOfNullables_ReturnsValues(IList<int?> subject, IList<int> expected)
-        {
-            var result = subject.Compact();
-            result.Should().BeEquivalentTo(expected, opt => opt.WithStrictOrdering());
-        }
-
-        public static TheoryData<IList<int?>, IList<int>> Compact_WithEnumerableOfNullables_ReturnsValuesTestCases()
-        {
-            return new TheoryData<IList<int?>, IList<int>>
-            {
-                { new int?[] { }, new int[] { } },
-                { new int?[] { null }, new int[] { } },
-                { new int?[] { null, 1, null, 2, null, 3, null }, new int[] { 1, 2, 3 } },
-                { new int?[] { 1, 2, 3 }, new int[] { 1, 2, 3 } },
-            };
-        }
-
         [Fact]
-        public void Compact_ConstrainedStructNullArgument_ShouldThrow()
+        public void Values_MaybeNullArgument_ShouldThrow()
         {
-            Action subject = () => ((int?[])null).Compact();
-
-            subject.Should().ThrowExactly<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void Compact_MaybeNullArgument_ShouldThrow()
-        {
-            Action subject = () => ((IEnumerable<Maybe<int>>)null).Compact();
+            Action subject = () => ((IEnumerable<Maybe<int>>)null).Values();
 
             subject.Should().ThrowExactly<ArgumentNullException>();
         }

--- a/Maybe/MaybeEnumerableExtensions.cs
+++ b/Maybe/MaybeEnumerableExtensions.cs
@@ -7,7 +7,7 @@ namespace Maybe
     /// <summary>
     /// Contains extensions methods for enumerables.
     /// </summary>
-    public static class MaybeEnumerableExtentions
+    public static class MaybeEnumerableExtensions
     {
         #region Empties
         /// <summary>
@@ -459,7 +459,7 @@ namespace Maybe
         }
         #endregion
 
-        #region Compact
+        #region Values
         /// <summary>
         /// Extract the values from source, ignoring Maybe.Nothing.
         /// </summary>
@@ -467,28 +467,12 @@ namespace Maybe
         /// An IEnumerable&lt;<typeparamref name="T"/>&gt; with all the values in source, ignoring Maybe.Nothing.
         /// </returns>
         /// <param name="source"> The source.</param>
-        public static IEnumerable<T> Compact<T>(this IEnumerable<Maybe<T>> source)
+        public static IEnumerable<T> Values<T>(this IEnumerable<Maybe<T>> source)
         {
             source = source ?? throw new ArgumentNullException(nameof(source));
 
             return source.Where(m => m.HasValue).Select(m => m.Value);
         }
-
-        /// <summary>
-        /// Extract the values from source, ignoring nulls.
-        /// </summary>
-        /// <returns>
-        /// An IEnumerable&lt;<typeparamref name="T"/>&gt; with all the values in source, ignoring nulls.
-        /// </returns>
-        /// <param name="source"> The source.</param>
-        public static IEnumerable<T> Compact<T>(this IEnumerable<T?> source)
-            where T : struct
-        {
-            source = source ?? throw new ArgumentNullException(nameof(source));
-
-            return source.Where(m => m.HasValue).Select(m => m.Value);
-        }
-
         #endregion
     }
 }

--- a/Maybe/MaybeExtensions.cs
+++ b/Maybe/MaybeExtensions.cs
@@ -5,7 +5,7 @@ namespace Maybe
     /// <summary>
     /// Contains extensions methods for the maybe class.
     /// </summary>
-    public static class MaybeExtentions
+    public static class MaybeExtensions
     {
         #region Defaults Values
         /// <summary>


### PR DESCRIPTION
Renamed method extensions `Compact` to `Values`. Also removed method `IEnumerable<T> Compact<T>(this IEnumerable<T?> source)` because it has nothing to do with Maybes.